### PR TITLE
Update results page filters

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,6 +12,7 @@ export default function KaraokeSearchApp() {
   const [selectedStore, setSelectedStore] = useState<Store | null>(null)
   const [searchLocation, setSearchLocation] = useState("")
   const [duration, setDuration] = useState([2.5])
+  const [startTime, setStartTime] = useState("18:00")
   const [people, setPeople] = useState(2)
   const [studentDiscount, setStudentDiscount] = useState(false)
   const [drinkBar, setDrinkBar] = useState(false)
@@ -49,6 +50,8 @@ export default function KaraokeSearchApp() {
       <SearchPage
         searchLocation={searchLocation}
         setSearchLocation={setSearchLocation}
+        startTime={startTime}
+        setStartTime={setStartTime}
         duration={duration}
         setDuration={setDuration}
         people={people}
@@ -72,6 +75,11 @@ export default function KaraokeSearchApp() {
         viewMode={viewMode}
         setViewMode={setViewMode}
         stores={mockStores}
+        searchLocation={searchLocation}
+        startTime={startTime}
+        duration={duration}
+        people={people}
+        studentDiscount={studentDiscount}
         membershipSettings={membershipSettings}
         onStoreSelect={setSelectedStore}
       />

--- a/frontend/app/pages/ResultsPage.tsx
+++ b/frontend/app/pages/ResultsPage.tsx
@@ -9,6 +9,11 @@ interface ResultsPageProps {
   viewMode: "list" | "map"
   setViewMode: (mode: "list" | "map") => void
   stores: Store[]
+  searchLocation: string
+  startTime: string
+  duration: number[]
+  people: number
+  studentDiscount: boolean
   membershipSettings: MembershipSettings
   onStoreSelect: (store: Store) => void
 }
@@ -18,9 +23,36 @@ export function ResultsPage({
   viewMode,
   setViewMode,
   stores,
+  searchLocation,
+  startTime,
+  duration,
+  people,
+  studentDiscount,
   membershipSettings,
   onStoreSelect,
 }: ResultsPageProps) {
+  const formatDuration = (hours: number) => {
+    const h = Math.floor(hours)
+    const m = Math.round((hours - h) * 60)
+    if (h === 0) return `${m}分`
+    if (m === 0) return `${h}時間`
+    return `${h}時間${m}分`
+  }
+
+  const chainNameMap: Record<string, string> = {
+    karaokeCan: 'カラオケ館',
+    bigEcho: 'ビッグエコー',
+    tetsuJin: 'カラオケの鉄人',
+    manekineko: 'まねきねこ',
+    jankara: 'ジャンカラ',
+    utahiroba: '歌広場',
+  }
+
+  const memberStoreLabel = Object.entries(membershipSettings)
+    .filter(([, v]) => v.isMember)
+    .map(([k]) => chainNameMap[k] || k)
+    .join('、')
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -35,17 +67,25 @@ export function ResultsPage({
       <div className="px-4 py-3 bg-white border-b">
         <div className="flex gap-2 overflow-x-auto">
           <Badge variant="outline" className="whitespace-nowrap">
-            半径1km以内
+            {searchLocation || "場所未指定"}
           </Badge>
           <Badge variant="outline" className="whitespace-nowrap">
-            24時間営業
+            {`開始 ${startTime}`}
           </Badge>
           <Badge variant="outline" className="whitespace-nowrap">
-            フリータイム
+            {`利用 ${formatDuration(duration[0])}`}
           </Badge>
           <Badge variant="outline" className="whitespace-nowrap">
-            学割対応
+            {`${people}人`}
           </Badge>
+          <Badge variant="outline" className="whitespace-nowrap">
+            {studentDiscount ? "学割利用" : "学割なし"}
+          </Badge>
+          {memberStoreLabel && (
+            <Badge variant="outline" className="whitespace-nowrap">
+              {`会員: ${memberStoreLabel}`}
+            </Badge>
+          )}
         </div>
       </div>
 

--- a/frontend/app/pages/ResultsPage.tsx
+++ b/frontend/app/pages/ResultsPage.tsx
@@ -65,7 +65,7 @@ export function ResultsPage({
 
       {/* Filter Chips */}
       <div className="px-4 py-3 bg-white border-b">
-        <div className="flex gap-2 overflow-x-auto">
+        <div className="flex flex-wrap gap-2">
           <Badge variant="outline" className="whitespace-nowrap">
             {searchLocation || "場所未指定"}
           </Badge>
@@ -82,9 +82,11 @@ export function ResultsPage({
             {studentDiscount ? "学割利用" : "学割なし"}
           </Badge>
           {memberStoreLabel && (
-            <Badge variant="outline" className="whitespace-nowrap">
-              {`会員: ${memberStoreLabel}`}
-            </Badge>
+            <div className="basis-full">
+              <Badge variant="outline" className="whitespace-nowrap">
+                {`会員: ${memberStoreLabel}`}
+              </Badge>
+            </div>
           )}
         </div>
       </div>

--- a/frontend/app/pages/SearchPage.tsx
+++ b/frontend/app/pages/SearchPage.tsx
@@ -10,6 +10,8 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 interface SearchPageProps {
   searchLocation: string
   setSearchLocation: (location: string) => void
+  startTime: string
+  setStartTime: (time: string) => void
   duration: number[]
   setDuration: (duration: number[]) => void
   people: number
@@ -27,6 +29,8 @@ interface SearchPageProps {
 export function SearchPage({
   searchLocation,
   setSearchLocation,
+  startTime,
+  setStartTime,
   duration,
   setDuration,
   people,
@@ -88,7 +92,13 @@ export function SearchPage({
                   <Clock className="w-4 h-4" />
                   開始時間
                 </label>
-                <Input type="time" defaultValue="18:00" />
+                <Input
+                  type="time"
+                  value={startTime}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setStartTime(e.target.value)
+                  }
+                />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium">利用時間</label>


### PR DESCRIPTION
## Summary
- add start time prop to SearchPage
- track start time in root state
- pass search criteria to ResultsPage and display

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d15f712888325957d97d676436aa3