### PR TITLE
Add karaoke chain logos

### DIFF
--- a/frontend/app/pages/ResultsPage.tsx
+++ b/frontend/app/pages/ResultsPage.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Map, List, Navigation, Star } from "lucide-react"
 import { Store, MembershipSettings } from "../types/store"
+import Image from "next/image"
 
 interface ResultsPageProps {
   onBack: () => void
@@ -46,6 +47,15 @@ export function ResultsPage({
     manekineko: 'まねきねこ',
     jankara: 'ジャンカラ',
     utahiroba: '歌広場',
+  }
+
+  const chainLogoMap: Record<string, string> = {
+    karaokeCan: '/karaokeCan.png',
+    bigEcho: '/bigEcho.jpeg',
+    tetsuJin: '/karaokeTetsujin.jpeg',
+    manekineko: '/manekiNeko.jpg',
+    jankara: '/jyanKara.jpg',
+    utahiroba: '/utahiroba.jpeg',
   }
 
   const memberStoreLabel = Object.entries(membershipSettings)
@@ -110,8 +120,14 @@ export function ResultsPage({
               <Card key={store.id} className="shadow-sm cursor-pointer hover:shadow-md transition-shadow">
                 <CardContent className="p-4" onClick={() => onStoreSelect(store)}>
                   <div className="flex items-start gap-3">
-                    <div className="w-12 h-12 bg-indigo-100 rounded-full flex items-center justify-center">
-                      <span className="text-indigo-600 font-bold text-sm">{store.chain.charAt(0)}</span>
+                    <div className="w-12 h-12 rounded-full overflow-hidden flex items-center justify-center bg-white border">
+                      <Image
+                        src={chainLogoMap[store.chainKey] || '/placeholder-logo.png'}
+                        alt={store.chain}
+                        width={48}
+                        height={48}
+                        className="object-contain w-full h-full"
+                      />
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-start justify-between gap-2">

--- a/frontend/app/pages/StoreDetail.tsx
+++ b/frontend/app/pages/StoreDetail.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge"
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { MapPin, Phone, Star } from "lucide-react"
 import { Store, MembershipSettings } from "../types/store"
+import Image from "next/image"
 
 interface StoreDetailProps {
   store: Store | null
@@ -17,14 +18,29 @@ export function StoreDetail({ store, onClose, membershipSettings }: StoreDetailP
   const memberPrice = store.memberPrice
   const regularPrice = store.price
 
+  const chainLogoMap: Record<string, string> = {
+    karaokeCan: '/karaokeCan.png',
+    bigEcho: '/bigEcho.jpeg',
+    tetsuJin: '/karaokeTetsujin.jpeg',
+    manekineko: '/manekiNeko.jpg',
+    jankara: '/jyanKara.jpg',
+    utahiroba: '/utahiroba.jpeg',
+  }
+
   return (
     <Sheet open={!!store} onOpenChange={onClose}>
       <SheetContent side="bottom" className="h-[90vh] rounded-t-xl">
         <div className="py-6 space-y-6">
           {/* Store Header */}
           <div className="text-center">
-            <div className="w-16 h-16 bg-indigo-100 rounded-full flex items-center justify-center mx-auto mb-3">
-              <span className="text-indigo-600 font-bold text-xl">{store.chain.charAt(0)}</span>
+            <div className="w-16 h-16 rounded-full overflow-hidden flex items-center justify-center mx-auto mb-3 bg-white border">
+              <Image
+                src={chainLogoMap[store.chainKey] || '/placeholder-logo.png'}
+                alt={store.chain}
+                width={64}
+                height={64}
+                className="object-contain w-full h-full"
+              />
             </div>
             <h2 className="text-xl font-bold text-gray-900">{store.name}</h2>
             <p className="text-gray-500">{store.address}</p>


### PR DESCRIPTION
## Summary
- show karaoke chain logos in results and store detail pages
- add logo mappings for each chain

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d27867d748325b66e64e711bb89b7