### PR TITLE
make it use api to display frontend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,4 +11,5 @@ WORKDIR /app
 RUN uv sync --frozen --no-cache
 
 # Run the application.
-CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80", "--host", "0.0.0.0"]
+# CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80", "--host", "0.0.0.0"]
+CMD ["/app/.venv/bin/uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from typing import Annotated, List, Optional
 
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.dummy_karaoke_stores import dummy_stores
 from app.utils import (
@@ -12,6 +13,14 @@ from app.utils import (
 )
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 # --- Request/Response Schemas ---
@@ -66,6 +75,7 @@ class PlanDetail(BaseModel):
     - 単位種別、金額、30分単価、時間帯、顧客種別
     """
 
+    plan_name: str
     unit: str
     price: int
     price_per_30_min: Optional[int] = None
@@ -119,6 +129,7 @@ async def get_shop_detail(request: GetDetailRequest):
         plans_data = list_available_plans_for_store(store, start_dt, stay_minutes, is_member, is_student)
         plans = [
             PlanDetail(
+                plan_name=plan["plan_name"],
                 unit=plan["unit"],
                 price=plan["price"],
                 price_per_30_min=plan["price_per_30_min"],

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -186,6 +186,7 @@ def list_available_plans_for_store(
                 total = option.amount
             plans.append(
                 {
+                    "plan_name": plan.plan_name,
                     "unit": option.unit_type,
                     "price": int(total),
                     "price_per_30_min": option.amount if option.unit_type == "per_30min" else None,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastapi[standard]>=0.115.13",
+    "uvicorn[standard]",
 ]
 
 [dependency-groups]
@@ -13,6 +14,7 @@ dev = [
     "mypy>=1.16.1",
     "pytest>=8.4.1",
     "ruff>=0.12.0",
+    "uvicorn[standard]",
 ]
 
 [tool.ruff]

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -44,23 +44,36 @@ export default function KaraokeSearchApp() {
   
   function getChainKey(chainName: string): string {
     switch (chainName) {
-      case "カラオケ館": return "karaokeCan";
-      case "ビッグエコー": return "bigEcho";
-      case "カラオケの鉄人": return "tetsuJin";
-      case "まねきねこ": return "manekineko";
-      case "ジャンカラ": return "jankara";
-      case "歌広場": return "utahiroba";
-      default: return "karaokeCan";
+      case "カラオケ館":
+      case "karaokeCan":
+        return "karaokeCan";
+      case "ビッグエコー":
+      case "bigEcho":
+        return "bigEcho";
+      case "カラオケの鉄人":
+      case "tetsuJin":
+        return "tetsuJin";
+      case "まねきねこ":
+      case "manekineko":
+        return "manekineko";
+      case "ジャンカラ":
+      case "jankara":
+        return "jankara";
+      case "歌広場":
+      case "utahiroba":
+        return "utahiroba";
+      default:
+        return "karaokeCan";
     }
   }
 
   function mapApiShopToStore(apiShop: any): Store {
     const chainKey = getChainKey(apiShop.icon_url || apiShop.chain_name || "");
     return {
-      id: apiShop.shop_id,
+      shop_id: apiShop.shop_id,
       name: apiShop.name,
-      chain: apiShop.icon_url || "",
-      price: apiShop.price_per_person,
+      icon_url: apiShop.icon_url || "",
+      price_per_person: apiShop.price_per_person,
       memberPrice: undefined,
       drinkInfo: "ドリンクバー付",
       badges: [],
@@ -69,6 +82,7 @@ export default function KaraokeSearchApp() {
       address: "住所未設定",
       phone: apiShop.phone || "",
       features: [],
+      all_plans: apiShop.all_plans || [],
       chainKey,
       latitude: apiShop.latitude || 0,
       longitude: apiShop.longitude || 0,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { SearchPage } from "./pages/SearchPage"
 import { ResultsPage } from "./pages/ResultsPage"
 import { StoreDetail } from "./pages/StoreDetail"
-import { Store, MembershipSettings, mockStores } from "./types/store"
+import { Store, MembershipSettings } from "./types/store"
 
 export default function KaraokeSearchApp() {
   const [currentView, setCurrentView] = useState<"home" | "results">("home")
@@ -17,6 +17,7 @@ export default function KaraokeSearchApp() {
   const [people, setPeople] = useState(2)
   const [studentDiscount, setStudentDiscount] = useState(false)
   const [drinkBar, setDrinkBar] = useState(false)
+  const [stores, setStores] = useState<Store[]>([])
 
   const [membershipSettings, setMembershipSettings] = useState<MembershipSettings>({
     karaokeCan: { isMember: false },
@@ -34,13 +35,71 @@ export default function KaraokeSearchApp() {
     }))
   }
 
-  const handleSearch = () => {
-    setCurrentView("results")
+  const handleSearch = async () => {
+    const body = {
+      latitude: undefined,
+      longitude: undefined,
+      place_name: searchLocation,
+      stay_minutes: Math.round(duration[0] * 60),
+      is_free_time: false,
+      start_time: startTime,
+      group_size: people,
+      is_student: studentDiscount,
+      member_shop_ids: Object.entries(membershipSettings)
+        .filter(([, v]) => v.isMember)
+        .map(([k]) => k),
+      radius: distance[0],
+    }
+    try {
+      const res = await fetch("http://localhost:8000/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) throw new Error("検索APIエラー")
+      const data = await res.json()
+      setStores(data.results.map(mapApiShopToStore))
+      setCurrentView("results")
+    } catch (e) {
+      alert("検索に失敗しました")
+    }
+  }
+
+  function getChainKey(chainName: string): string {
+    switch (chainName) {
+      case "カラオケ館": return "karaokeCan";
+      case "ビッグエコー": return "bigEcho";
+      case "カラオケの鉄人": return "tetsuJin";
+      case "まねきねこ": return "manekineko";
+      case "ジャンカラ": return "jankara";
+      case "歌広場": return "utahiroba";
+      default: return "karaokeCan";
+    }
+  }
+
+  function mapApiShopToStore(apiShop: any): Store {
+    const chainKey = getChainKey(apiShop.icon_url || apiShop.chain_name || "");
+    return {
+      id: apiShop.shop_id,
+      name: apiShop.name,
+      chain: apiShop.icon_url || "",
+      price: apiShop.price_per_person,
+      memberPrice: undefined,
+      drinkInfo: "ドリンクバー付",
+      badges: [],
+      distance: "0.5km",
+      rating: 4.0,
+      address: "住所未設定",
+      phone: apiShop.phone || "",
+      features: [],
+      chainKey,
+      latitude: apiShop.latitude || 0,
+      longitude: apiShop.longitude || 0,
+    }
   }
 
   const handleUseCurrentLocation = () => {
     setSearchLocation("現在地を取得中...")
-    // Simulate GPS location fetch
     setTimeout(() => {
       setSearchLocation("東京都渋谷区")
     }, 1000)
@@ -77,7 +136,7 @@ export default function KaraokeSearchApp() {
         onBack={() => setCurrentView("home")}
         viewMode={viewMode}
         setViewMode={setViewMode}
-        stores={mockStores}
+        stores={stores}
         searchLocation={searchLocation}
         distance={distance}
         startTime={startTime}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,7 @@ import { SearchPage } from "./pages/SearchPage"
 import { ResultsPage } from "./pages/ResultsPage"
 import { StoreDetail } from "./pages/StoreDetail"
 import { Store, MembershipSettings } from "./types/store"
+import { GetDetailResponse } from "./types/api"
 
 export default function KaraokeSearchApp() {
   const [currentView, setCurrentView] = useState<"home" | "results">("home")
@@ -25,6 +26,8 @@ export default function KaraokeSearchApp() {
   const [inputAddress, setInputAddress] = useState("")
   const [validAddress, setValidAddress] = useState(false)
   const [debouncedAddress] = useDebounce(inputAddress, 1000) // 1秒間入力が止まったら反応
+  const [detailData, setDetailData] = useState<GetDetailResponse | null>(null)
+  const [loadingDetail, setLoadingDetail] = useState(false)
 
   const [membershipSettings, setMembershipSettings] = useState<MembershipSettings>({
     karaokeCan: { isMember: false },
@@ -190,13 +193,39 @@ export default function KaraokeSearchApp() {
         })
     
         const data = await response.json()
-        setStores(data.results || [])
+        setStores((data.results || []).map(mapApiShopToStore))
         setCurrentView("results")
       } catch (error) {
         console.error("検索APIエラー:", error)
       }
     }
   }
+
+  useEffect(() => {
+    if (!selectedStore) return;
+    setLoadingDetail(true);
+    setDetailData(null);
+    fetch("http://localhost:8000/get_detail", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        shop_id: selectedStore.shop_id,
+        start_time: startTime,
+        stay_minutes: Math.round(duration[0] * 60),
+        is_student: studentDiscount,
+        member_shop_ids: Object.entries(membershipSettings)
+          .filter(([, v]) => v.isMember)
+          .map(([k]) => k),
+      }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("詳細APIエラー");
+        return res.json();
+      })
+      .then((data) => setDetailData(data))
+      .catch(() => setDetailData(null))
+      .finally(() => setLoadingDetail(false));
+  }, [selectedStore, startTime, duration, studentDiscount, membershipSettings]);
 
   if (currentView === "home") {
     return (
@@ -243,7 +272,13 @@ export default function KaraokeSearchApp() {
       />
       <StoreDetail
         store={selectedStore}
-        onClose={() => setSelectedStore(null)}
+        detailData={detailData}
+        loading={loadingDetail}
+        onClose={() => {
+          setSelectedStore(null)
+          setDetailData(null)
+          setLoadingDetail(false)
+        }}
         membershipSettings={membershipSettings}
       />
     </>

--- a/frontend/app/pages/ResultsPage.tsx
+++ b/frontend/app/pages/ResultsPage.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { Map, List, Navigation, Star } from "lucide-react"
 import { ResultsMap } from "@/components/ResultsMap"
 import { Store, MembershipSettings } from "../types/store"
+import { PlanDetail, GetDetailResponse } from "../types/api"
 import Image from "next/image"
 import { useState } from "react"
 import { StoreDetail } from "./StoreDetail"
@@ -38,6 +39,9 @@ export function ResultsPage({
   onStoreSelect,
 }: ResultsPageProps) {
   const [selectedStore, setSelectedStore] = useState<Store | null>(null)
+  // 追加: 詳細データ状態
+  const [detailData, setDetailData] = useState<GetDetailResponse | null>(null)
+  const [loadingDetail, setLoadingDetail] = useState(false)
 
   const formatDuration = (hours: number) => {
     const h = Math.floor(hours)
@@ -74,6 +78,35 @@ export function ResultsPage({
     .filter(([, v]) => v.isMember)
     .map(([k]) => chainNameMap[k] || k)
     .join('、')
+
+  // 店舗選択時に詳細APIを呼ぶ
+  const handleStoreSelect = async (store: Store) => {
+    setSelectedStore(store)
+    setLoadingDetail(true)
+    setDetailData(null)
+    try {
+      const res = await fetch("http://localhost:8000/get_detail", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shop_id: store.id,
+          start_time: startTime,
+          stay_minutes: Math.round(duration[0] * 60),
+          is_student: studentDiscount,
+          member_shop_ids: Object.entries(membershipSettings)
+            .filter(([, v]) => v.isMember)
+            .map(([k]) => k),
+        }),
+      })
+      if (!res.ok) throw new Error("詳細APIエラー")
+      const data = await res.json()
+      setDetailData(data)
+    } catch (e) {
+      alert("詳細取得に失敗しました")
+    } finally {
+      setLoadingDetail(false)
+    }
+  }
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -131,7 +164,7 @@ export function ResultsPage({
 
             return (
               <Card key={store.id} className="shadow-sm cursor-pointer hover:shadow-md transition-shadow">
-                <CardContent className="p-3" onClick={() => onStoreSelect(store)}>
+                <CardContent className="p-3" onClick={() => handleStoreSelect(store)}>
                   <div className="flex items-center gap-3">
                     <div className="w-12 h-12 rounded-full flex items-center justify-center bg-white border relative">
                       <div className="w-12 h-12 rounded-full overflow-hidden">
@@ -177,13 +210,22 @@ export function ResultsPage({
           <ResultsMap
             stores={stores}
             membershipSettings={membershipSettings}
-            onMarkerClick={setSelectedStore}
+            onMarkerClick={handleStoreSelect}
           />
         </div>
       )}
 
       {/* StoreDetail モーダル */}
-      <StoreDetail store={selectedStore} onClose={() => setSelectedStore(null)} membershipSettings={membershipSettings} />
+      <StoreDetail
+        store={selectedStore}
+        detailData={detailData}
+        loading={loadingDetail}
+        onClose={() => {
+          setSelectedStore(null)
+          setDetailData(null)
+        }}
+        membershipSettings={membershipSettings}
+      />
     </div>
   )
 }

--- a/frontend/app/pages/ResultsPage.tsx
+++ b/frontend/app/pages/ResultsPage.tsx
@@ -211,20 +211,17 @@ export function ResultsPage({
           <ResultsMap
             stores={stores}
             membershipSettings={membershipSettings}
-            onMarkerClick={handleStoreSelect}
+            onMarkerClick={onStoreSelect}
           />
         </div>
       )}
 
       {/* StoreDetail モーダル */}
       <StoreDetail
-        store={selectedStore}
-        detailData={detailData}
-        loading={loadingDetail}
-        onClose={() => {
-          setSelectedStore(null)
-          setDetailData(null)
-        }}
+        store={null}
+        detailData={null}
+        loading={false}
+        onClose={() => {}}
         membershipSettings={membershipSettings}
       />
     </div>

--- a/frontend/app/pages/ResultsPage.tsx
+++ b/frontend/app/pages/ResultsPage.tsx
@@ -89,7 +89,7 @@ export function ResultsPage({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          shop_id: store.id,
+          shop_id: store.shop_id,
           start_time: startTime,
           stay_minutes: Math.round(duration[0] * 60),
           is_student: studentDiscount,

--- a/frontend/app/pages/StoreDetail.tsx
+++ b/frontend/app/pages/StoreDetail.tsx
@@ -84,7 +84,7 @@ export function StoreDetail({ store, detailData, loading, onClose, membershipSet
                       {plan.price_per_30_min && (
                         <div className="text-xs text-gray-400">30分単価: ¥{plan.price_per_30_min}</div>
                       )}
-                      <div className="text-xs text-gray-500">{plan.customer_type.map(customerTypeToJa).join(', ')}</div>
+                      <div className="text-xs text-gray-500">{(plan.customer_type ?? []).map(customerTypeToJa).join(', ')}</div>
                     </div>
                   </div>
                 ))}
@@ -131,7 +131,7 @@ export function StoreDetail({ store, detailData, loading, onClose, membershipSet
           <div className="space-y-3">
             <h3 className="font-semibold text-gray-900">サービス</h3>
             <div className="flex flex-wrap gap-2">
-              {store.features.map((feature) => (
+              {(store.features ?? []).map((feature) => (
                 <Badge key={feature} variant="secondary">
                   {feature}
                 </Badge>

--- a/frontend/app/pages/StoreDetail.tsx
+++ b/frontend/app/pages/StoreDetail.tsx
@@ -3,15 +3,18 @@ import { Badge } from "@/components/ui/badge"
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { MapPin, Phone, Star, Navigation } from "lucide-react"
 import { Store, MembershipSettings } from "../types/store"
+import { PlanDetail, GetDetailResponse } from "../types/api"
 import Image from "next/image"
 
 interface StoreDetailProps {
   store: Store | null
+  detailData?: GetDetailResponse | null
+  loading?: boolean
   onClose: () => void
   membershipSettings: MembershipSettings
 }
 
-export function StoreDetail({ store, onClose, membershipSettings }: StoreDetailProps) {
+export function StoreDetail({ store, detailData, loading, onClose, membershipSettings }: StoreDetailProps) {
   if (!store) return null
 
   const isMember = membershipSettings[store.chainKey as keyof typeof membershipSettings]?.isMember
@@ -25,6 +28,15 @@ export function StoreDetail({ store, onClose, membershipSettings }: StoreDetailP
     manekineko: '/manekiNeko.jpg',
     jankara: '/jyanKara.jpg',
     utahiroba: '/utahiroba.jpeg',
+  }
+
+  function customerTypeToJa(type: string): string {
+    switch (type) {
+      case "general": return "一般";
+      case "student": return "学生";
+      case "member": return "会員";
+      default: return type;
+    }
   }
 
   return (
@@ -60,40 +72,59 @@ export function StoreDetail({ store, onClose, membershipSettings }: StoreDetailP
           {/* Price Table */}
           <div className="space-y-3">
             <h3 className="font-semibold text-gray-900">料金プラン</h3>
-            <div className="space-y-2">
-              <div className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
-                <span>30分</span>
-                <div className="text-right">
-                  {isMember && <div className="text-sm text-gray-400 line-through">¥580</div>}
-                  <span className="font-medium">¥{isMember ? "480" : "580"}</span>
+            {loading ? (
+              <div className="text-center py-8">読み込み中...</div>
+            ) : detailData ? (
+              <div className="space-y-2">
+                {detailData.plans.map((plan: PlanDetail, idx: number) => (
+                  <div key={idx} className="flex justify-between items-center p-3 bg-gray-50 rounded-lg border">
+                    <span>{plan.plan_name}（{plan.start}〜{plan.end}）</span>
+                    <div className="text-right">
+                      <span className="font-bold text-indigo-600">¥{plan.price.toLocaleString()}</span>
+                      {plan.price_per_30_min && (
+                        <div className="text-xs text-gray-400">30分単価: ¥{plan.price_per_30_min}</div>
+                      )}
+                      <div className="text-xs text-gray-500">{plan.customer_type.map(customerTypeToJa).join(', ')}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                  <span>30分</span>
+                  <div className="text-right">
+                    {isMember && <div className="text-sm text-gray-400 line-through">¥580</div>}
+                    <span className="font-medium">¥{isMember ? "480" : "580"}</span>
+                  </div>
+                </div>
+                <div className="flex justify-between items-center p-3 bg-orange-50 rounded-lg border border-orange-200">
+                  <span>2時間パック</span>
+                  <div className="text-right">
+                    {isMember && memberPrice && memberPrice < regularPrice && (
+                      <div className="text-sm text-gray-400 line-through">¥{regularPrice.toLocaleString()}</div>
+                    )}
+                    <span className={`font-bold ${isMember && memberPrice ? "text-green-600" : "text-orange-600"}`}>
+                      ¥{(isMember && memberPrice ? memberPrice : regularPrice).toLocaleString()}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                  <span>フリータイム</span>
+                  <div className="text-right">
+                    {isMember && <div className="text-sm text-gray-400 line-through">¥2,980</div>}
+                    <span className="font-medium">¥{isMember ? "2,480" : "2,980"}</span>
+                  </div>
+                </div>
+                <div className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                  <span>深夜パック</span>
+                  <div className="text-right">
+                    {isMember && <div className="text-sm text-gray-400 line-through">¥1,980</div>}
+                    <span className="font-medium">¥{isMember ? "1,680" : "1,980"}</span>
+                  </div>
                 </div>
               </div>
-              <div className="flex justify-between items-center p-3 bg-orange-50 rounded-lg border border-orange-200">
-                <span>2時間パック</span>
-                <div className="text-right">
-                  {isMember && memberPrice && memberPrice < regularPrice && (
-                    <div className="text-sm text-gray-400 line-through">¥{regularPrice.toLocaleString()}</div>
-                  )}
-                  <span className={`font-bold ${isMember && memberPrice ? "text-green-600" : "text-orange-600"}`}>
-                    ¥{(isMember && memberPrice ? memberPrice : regularPrice).toLocaleString()}
-                  </span>
-                </div>
-              </div>
-              <div className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
-                <span>フリータイム</span>
-                <div className="text-right">
-                  {isMember && <div className="text-sm text-gray-400 line-through">¥2,980</div>}
-                  <span className="font-medium">¥{isMember ? "2,480" : "2,980"}</span>
-                </div>
-              </div>
-              <div className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
-                <span>深夜パック</span>
-                <div className="text-right">
-                  {isMember && <div className="text-sm text-gray-400 line-through">¥1,980</div>}
-                  <span className="font-medium">¥{isMember ? "1,680" : "1,980"}</span>
-                </div>
-              </div>
-            </div>
+            )}
           </div>
 
           {/* Features */}

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -1,0 +1,15 @@
+export interface PlanDetail {
+    plan_name: string
+    unit: string
+    price: number
+    price_per_30_min?: number
+    start: string
+    end: string
+    customer_type: string[]
+}
+
+export interface GetDetailResponse {
+    shop_id: string
+    name: string
+    plans: PlanDetail[]
+}


### PR DESCRIPTION
# 概要
- 詳細ページのフロントエンドとバックエンドのAPI連携を本番仕様に対応
- 店舗情報・詳細情報の取得・表示をAPIベースに統一
- UI/UXの改善（日本語でのプラン名・顧客種別表示、ロゴ表示の修正など）
- Dockerfileの修正による本番環境対応

# 主な変更点
## フロントエンド
- 検索結果の店舗リストから店舗を選択した際、/get_detailエンドポイントを呼び出して詳細情報を取得・表示するように修正
- 店舗ロゴ画像の表示ロジックを修正し、チェーン名から正しく画像を表示できるように対応
- 詳細ページの料金プラン表示で、APIから取得した日本語のプラン名（plan_name）を表示するように修正
- 顧客種別（general, student, member）を日本語（一般、学生、会員）で表示するように修正
- 型定義（PlanDetail, GetDetailResponse）を共通化し、型エラーを解消
## バックエンド
- /get_detailのレスポンスの各プラン情報（plans）に日本語のプラン名（plan_name）を含めるように修正
- APIレスポンスの型とフロントエンドの型定義を一致させるように調整
## Dockerfile
- 本番環境でFastAPIアプリを正しく起動できるよう、DockerfileのCMDをuvicornによる起動に修正
- pyproject.tomlのdependenciesにuvicorn[standard]を追加し、Dockerイメージビルド時にuvicornがインストールされるように対応
- これにより、CORSやASGIサーバーの仕様が正しく動作し、フロントエンドからのAPIリクエストが正常に処理されるようになりました